### PR TITLE
:recycle: Name unpack result same name as codec

### DIFF
--- a/.changeset/wet-lobsters-roll.md
+++ b/.changeset/wet-lobsters-roll.md
@@ -1,0 +1,14 @@
+---
+"@ckb-cobuild/cobuild": major
+---
+
+Name unpack result same name as codec.
+
+- Move all codecs in `@ckb-lumos/codec` to a module `builtins`.
+- Name all unpack result types using the same name as the codec itself.
+
+Example:
+
+```
+export type BuildingPacket = UnpackResult<typeof BuildingPacket>;
+```

--- a/packages/cobuild/src/__tests__/building-packet.test.ts
+++ b/packages/cobuild/src/__tests__/building-packet.test.ts
@@ -1,14 +1,13 @@
 import { BI } from "@ckb-lumos/bi";
 import {
   BuildingPacket,
-  BuildingPacketUnpackResult,
   getInputCell,
   getOutputCell,
 } from "../building-packet";
 import { makeByte32 } from "../factory";
 
 describe("BuildingPacket", () => {
-  const sampleBuildingPacket: BuildingPacketUnpackResult = {
+  const sampleBuildingPacket: BuildingPacket = {
     type: "BuildingPacketV1",
     value: {
       message: {

--- a/packages/cobuild/src/__tests__/json.test.ts
+++ b/packages/cobuild/src/__tests__/json.test.ts
@@ -8,7 +8,8 @@ import {
   molecule,
 } from "@ckb-lumos/codec";
 
-import { StringCodec, Uint32LE, BytesVec } from "..";
+import { StringCodec } from "..";
+import { Uint32LE, BytesVec } from "../builtins";
 import { fromJson, toJson } from "../json";
 
 const testCaseIn = {

--- a/packages/cobuild/src/__tests__/recipes.test.ts
+++ b/packages/cobuild/src/__tests__/recipes.test.ts
@@ -1,6 +1,7 @@
 import { BI } from "@ckb-lumos/bi";
 import { bytes } from "@ckb-lumos/codec";
 import { freeze, produce } from "immer";
+import { WitnessArgs } from "../builtins";
 import {
   makeBuildingPacket,
   makeByte32,
@@ -20,7 +21,7 @@ import {
   updateWitnessArgs,
   updateWitnessLayout,
 } from "../recipes";
-import { WitnessArgs, WitnessLayout } from "../witness-layout";
+import { WitnessLayout } from "../witness-layout";
 
 const emptyBuildingPacket = freeze(makeBuildingPacket());
 

--- a/packages/cobuild/src/__tests__/witness-layout.test.ts
+++ b/packages/cobuild/src/__tests__/witness-layout.test.ts
@@ -1,13 +1,12 @@
 import { blockchain } from "@ckb-lumos/base";
 import { PackParam } from "@ckb-lumos/codec";
-import {
-  tryParseWitness,
-  parseWitnessType,
-  WitnessLayout,
-  WitnessArgs,
-  WitnessLayoutUnpackResult,
-} from "../witness-layout";
+import { WitnessArgs } from "../builtins";
 import { makeByte32 } from "../factory";
+import {
+  WitnessLayout,
+  parseWitnessType,
+  tryParseWitness,
+} from "../witness-layout";
 
 const { Bytes } = blockchain;
 
@@ -103,7 +102,7 @@ describe("WitnessLayout", () => {
     ["SighashAllOnly", { seal: "0x10" }],
   ])("unpack(pack(%s))", (type, value) => {
     const unpack = WitnessLayout.unpack(
-      WitnessLayout.pack({ type, value } as WitnessLayoutUnpackResult),
+      WitnessLayout.pack({ type, value } as WitnessLayout),
     );
     expect(unpack).toEqual({ type, value });
   });

--- a/packages/cobuild/src/building-packet.ts
+++ b/packages/cobuild/src/building-packet.ts
@@ -5,23 +5,18 @@ import {
   UnpackResult,
   createBytesCodec,
   molecule,
-  number,
 } from "@ckb-lumos/codec";
-
 import { ActionVec, Message } from "./witness-layout";
-
-const { Uint32LE } = number;
-const { option, table, vector, union } = molecule;
-const {
+import {
   Byte32,
   BytesVec,
-  CellOutputVec,
-  OutPoint,
   CellInput,
-  Script,
   CellOutput,
-  CellDep,
-} = blockchain;
+  CellOutputVec,
+  Uint32LE,
+} from "./builtins";
+
+const { option, table, vector, union } = molecule;
 
 /** @group Molecule Codecs */
 export const Uint32Opt = option(Uint32LE);
@@ -47,7 +42,7 @@ export const StringCodec = createBytesCodec<string>({
 export const String = StringCodec;
 
 /**
- * @alpha The fields are not finalized in this strcutre
+ * @alpha The fields are not finalized in this structure
  * @group Molecule Codecs
  */
 export const ScriptInfo = table(
@@ -74,12 +69,10 @@ export const ResolvedInputs = table(
 );
 
 /** @group Molecule Unpack Result */
-export type TransactionUnpackResult = UnpackResult<
-  typeof blockchain.Transaction
->;
+export type Transaction = UnpackResult<typeof blockchain.Transaction>;
 type TransactionPackParam =
   | PackParam<typeof blockchain.Transaction>
-  | TransactionUnpackResult;
+  | Transaction;
 
 type TransactionPackFunction = (
   unpacked: TransactionPackParam,
@@ -119,42 +112,34 @@ export const BuildingPacketV1 = table(
 export const BuildingPacket = union({ BuildingPacketV1 }, ["BuildingPacketV1"]);
 
 /** @group Molecule Unpack Result */
-export type ScriptInfoUnpackResult = UnpackResult<typeof ScriptInfo>;
+export type Uint32Opt = UnpackResult<typeof Uint32Opt>;
 /** @group Molecule Unpack Result */
-export type ResolvedInputsUnpackResult = UnpackResult<typeof ResolvedInputs>;
+export type ScriptInfo = UnpackResult<typeof ScriptInfo>;
 /** @group Molecule Unpack Result */
-export type BuildingPacketV1UnpackResult = UnpackResult<
-  typeof BuildingPacketV1
->;
+export type ScriptInfoVec = UnpackResult<typeof ScriptInfoVec>;
 /** @group Molecule Unpack Result */
-export type BuildingPacketUnpackResult = UnpackResult<typeof BuildingPacket>;
+export type ResolvedInputs = UnpackResult<typeof ResolvedInputs>;
 /** @group Molecule Unpack Result */
-export type OutPointUnpackResult = UnpackResult<typeof OutPoint>;
+export type BuildingPacketV1 = UnpackResult<typeof BuildingPacketV1>;
 /** @group Molecule Unpack Result */
-export type CellInputUnpackResult = UnpackResult<typeof CellInput>;
-/** @group Molecule Unpack Result */
-export type ScriptUnpackResult = UnpackResult<typeof Script>;
-/** @group Molecule Unpack Result */
-export type CellOutputUnpackResult = UnpackResult<typeof CellOutput>;
-/** @group Molecule Unpack Result */
-export type CellDepUnpackResult = UnpackResult<typeof CellDep>;
+export type BuildingPacket = UnpackResult<typeof BuildingPacket>;
 
 /** Bundle fields for a transaction input */
 export interface InputCell {
-  cellInput: CellInputUnpackResult;
-  cellOutput: CellOutputUnpackResult;
+  cellInput: CellInput;
+  cellOutput: CellOutput;
   data: string;
 }
 /** Bundle fields for a transaction output */
 export interface OutputCell {
-  cellOutput: CellOutputUnpackResult;
+  cellOutput: CellOutput;
   data: string;
 }
 export type Cell = InputCell | OutputCell;
 
 /** Get transaction input from three parallel lists. */
 export function getInputCell(
-  buildingPacket: BuildingPacketUnpackResult,
+  buildingPacket: BuildingPacket,
   index: number,
 ): InputCell | undefined {
   const result = {
@@ -173,7 +158,7 @@ export function getInputCell(
 
 /** Get transaction output from three parallel lists. */
 export function getOutputCell(
-  buildingPacket: BuildingPacketUnpackResult,
+  buildingPacket: BuildingPacket,
   index: number,
 ): OutputCell | undefined {
   const result = {

--- a/packages/cobuild/src/builtins.ts
+++ b/packages/cobuild/src/builtins.ts
@@ -1,0 +1,52 @@
+/**
+ * Builtin molecule codecs from `@ckb-lumos/codec`.
+ * @module
+ */
+import { blockchain } from "@ckb-lumos/base";
+import { number, UnpackResult } from "@ckb-lumos/codec";
+
+/** @group Molecule Codecs */
+export const Uint32LE = number.Uint32LE;
+/** @group Molecule Codecs */
+export const Byte32 = blockchain.Byte32;
+/** @group Molecule Codecs */
+export const Bytes = blockchain.Bytes;
+/** @group Molecule Codecs */
+export const BytesVec = blockchain.BytesVec;
+/** @group Molecule Codecs */
+export const CellOutputVec = blockchain.CellOutputVec;
+/** @group Molecule Codecs */
+export const OutPoint = blockchain.OutPoint;
+/** @group Molecule Codecs */
+export const CellInput = blockchain.CellInput;
+/** @group Molecule Codecs */
+export const Script = blockchain.Script;
+/** @group Molecule Codecs */
+export const CellOutput = blockchain.CellOutput;
+/** @group Molecule Codecs */
+export const CellDep = blockchain.CellDep;
+/** @group Molecule Codecs */
+export const WitnessArgs = blockchain.WitnessArgs;
+
+/** @group Molecule Unpack Result */
+export type Uint32LE = UnpackResult<typeof Uint32LE>;
+/** @group Molecule Unpack Result */
+export type Byte32 = UnpackResult<typeof Byte32>;
+/** @group Molecule Unpack Result */
+export type Bytes = UnpackResult<typeof Bytes>;
+/** @group Molecule Unpack Result */
+export type BytesVec = UnpackResult<typeof BytesVec>;
+/** @group Molecule Unpack Result */
+export type CellOutputVec = UnpackResult<typeof CellOutputVec>;
+/** @group Molecule Unpack Result */
+export type OutPoint = UnpackResult<typeof OutPoint>;
+/** @group Molecule Unpack Result */
+export type CellInput = UnpackResult<typeof CellInput>;
+/** @group Molecule Unpack Result */
+export type Script = UnpackResult<typeof Script>;
+/** @group Molecule Unpack Result */
+export type CellOutput = UnpackResult<typeof CellOutput>;
+/** @group Molecule Unpack Result */
+export type CellDep = UnpackResult<typeof CellDep>;
+/** @group Molecule Unpack Result */
+export type WitnessArgs = UnpackResult<typeof WitnessArgs>;

--- a/packages/cobuild/src/factory.ts
+++ b/packages/cobuild/src/factory.ts
@@ -8,26 +8,28 @@ import { BI, BIish } from "@ckb-lumos/bi";
 import { number } from "@ckb-lumos/codec";
 
 import {
-  BuildingPacketUnpackResult,
-  BuildingPacketV1UnpackResult,
-  CellDepUnpackResult,
-  CellInputUnpackResult,
-  CellOutputUnpackResult,
+  BuildingPacket,
+  BuildingPacketV1,
   InputCell,
-  OutPointUnpackResult,
   OutputCell,
-  ResolvedInputsUnpackResult,
-  ScriptInfoUnpackResult,
-  ScriptUnpackResult,
-  TransactionUnpackResult,
+  ResolvedInputs,
+  ScriptInfo,
+  Transaction,
 } from "./building-packet";
 import {
-  ActionUnpackResult,
-  MessageUnpackResult,
-  SighashAllOnlyUnpackResult,
-  SighashAllUnpackResult,
-  WitnessArgsUnpackResult,
-  WitnessLayoutUnpackResult,
+  CellDep,
+  CellInput,
+  CellOutput,
+  OutPoint,
+  Script,
+  WitnessArgs,
+} from "./builtins";
+import {
+  Action,
+  Message,
+  SighashAll,
+  SighashAllOnly,
+  WitnessLayout,
 } from "./witness-layout";
 
 const { Uint256 } = number;
@@ -57,14 +59,14 @@ export function makeAction({
   scriptInfoHash = BYTE32_ZEROS,
   scriptHash = BYTE32_ZEROS,
   data = "0x",
-}: FactoryParam<ActionUnpackResult> = {}): ActionUnpackResult {
+}: FactoryParam<Action> = {}): Action {
   return { scriptInfoHash, scriptHash, data };
 }
 
 /** @param attrs */
 export function makeMessage({
   actions = [],
-}: FactoryParam<MessageUnpackResult> = {}): MessageUnpackResult {
+}: FactoryParam<Message> = {}): Message {
   return { actions: actions.map(makeAction) };
 }
 
@@ -77,7 +79,7 @@ export function makePayload({
   cellDeps = [],
   headerDeps = [],
   witnesses = [],
-}: FactoryParam<TransactionUnpackResult> = {}): TransactionUnpackResult {
+}: FactoryParam<Transaction> = {}): Transaction {
   return {
     version,
     outputsData,
@@ -93,7 +95,7 @@ export function makePayload({
 export function makeResolvedInputs({
   outputs = [],
   outputsData = [],
-}: FactoryParam<ResolvedInputsUnpackResult> = {}): ResolvedInputsUnpackResult {
+}: FactoryParam<ResolvedInputs> = {}): ResolvedInputs {
   return { outputsData, outputs: outputs.map(makeCellOutput) };
 }
 
@@ -105,7 +107,7 @@ export function makeBuildingPacketV1({
   changeOutput,
   scriptInfos = [],
   lockActions = [],
-}: FactoryParam<BuildingPacketV1UnpackResult> = {}): BuildingPacketV1UnpackResult {
+}: FactoryParam<BuildingPacketV1> = {}): BuildingPacketV1 {
   return {
     changeOutput,
     message: makeMessage(message),
@@ -117,8 +119,8 @@ export function makeBuildingPacketV1({
 }
 
 export function makeBuildingPacket(
-  attrs: FactoryParam<BuildingPacketV1UnpackResult> = {},
-): BuildingPacketUnpackResult {
+  attrs: FactoryParam<BuildingPacketV1> = {},
+): BuildingPacket {
   return {
     type: "BuildingPacketV1",
     value: makeBuildingPacketV1(attrs),
@@ -132,7 +134,7 @@ export function makeScriptInfo({
   scriptHash = BYTE32_ZEROS,
   schema = "0x",
   messageType = "0x",
-}: FactoryParam<ScriptInfoUnpackResult> = {}): ScriptInfoUnpackResult {
+}: FactoryParam<ScriptInfo> = {}): ScriptInfo {
   return { name, url, scriptHash, schema, messageType };
 }
 
@@ -140,7 +142,7 @@ export function makeScriptInfo({
 export function makeOutPoint({
   txHash = BYTE32_ZEROS,
   index = 0,
-}: FactoryParam<OutPointUnpackResult> = {}): OutPointUnpackResult {
+}: FactoryParam<OutPoint> = {}): OutPoint {
   return { txHash, index };
 }
 
@@ -148,7 +150,7 @@ export function makeOutPoint({
 export function makeCellInput({
   previousOutput,
   since = BI_ZERO,
-}: FactoryParam<CellInputUnpackResult> = {}): CellInputUnpackResult {
+}: FactoryParam<CellInput> = {}): CellInput {
   return {
     previousOutput: makeOutPoint(previousOutput),
     since,
@@ -160,7 +162,7 @@ export function makeScript({
   codeHash = BYTE32_ZEROS,
   hashType = "data",
   args = "0x",
-}: FactoryParam<ScriptUnpackResult> = {}): ScriptUnpackResult {
+}: FactoryParam<Script> = {}): Script {
   return { codeHash, hashType, args };
 }
 
@@ -169,7 +171,7 @@ export function makeCellOutput({
   capacity = BI_ZERO,
   lock,
   type,
-}: FactoryParam<CellOutputUnpackResult> = {}): CellOutputUnpackResult {
+}: FactoryParam<CellOutput> = {}): CellOutput {
   return {
     capacity,
     lock: makeScript(lock),
@@ -203,7 +205,7 @@ export function makeOutputCell({
 export function makeCellDep({
   outPoint,
   depType = "code",
-}: FactoryParam<CellDepUnpackResult> = {}): CellDepUnpackResult {
+}: FactoryParam<CellDep> = {}): CellDep {
   return { outPoint: makeOutPoint(outPoint), depType };
 }
 
@@ -212,7 +214,7 @@ export function makeWitnessArgs({
   lock,
   inputType,
   outputType,
-}: FactoryParam<WitnessArgsUnpackResult> = {}): WitnessArgsUnpackResult {
+}: FactoryParam<WitnessArgs> = {}): WitnessArgs {
   return { lock, inputType, outputType };
 }
 
@@ -220,7 +222,7 @@ export function makeWitnessArgs({
 export function makeSighashAllWitnessLayout({
   message,
   seal = "0x",
-}: FactoryParam<SighashAllUnpackResult> = {}): WitnessLayoutUnpackResult {
+}: FactoryParam<SighashAll> = {}): WitnessLayout {
   return {
     type: "SighashAll",
     value: {
@@ -233,13 +235,13 @@ export function makeSighashAllWitnessLayout({
 /** @param attrs */
 export function makeSighashAllOnlyWitnessLayout({
   seal = "0x",
-}: FactoryParam<SighashAllOnlyUnpackResult> = {}): WitnessLayoutUnpackResult {
+}: FactoryParam<SighashAllOnly> = {}): WitnessLayout {
   return {
     type: "SighashAllOnly",
     value: { seal },
   };
 }
 
-export function makeDefaultWitnessLayout(): WitnessLayoutUnpackResult {
+export function makeDefaultWitnessLayout(): WitnessLayout {
   return makeSighashAllWitnessLayout({});
 }

--- a/packages/cobuild/src/index.ts
+++ b/packages/cobuild/src/index.ts
@@ -1,26 +1,6 @@
-import { blockchain } from "@ckb-lumos/base";
-import { number } from "@ckb-lumos/codec";
-
-const {
-  /** @group Molecule Codecs */
-  Uint32LE,
-} = number;
-
-const {
-  /** @group Molecule Codecs */
-  Bytes,
-  /** @group Molecule Codecs */
-  Byte32,
-  /** @group Molecule Codecs */
-  BytesVec,
-  /** @group Molecule Codecs */
-  CellOutputVec,
-} = blockchain;
-
 export * from "./building-packet";
+export * as builtins from "./builtins";
 export * as factory from "./factory";
 export * as json from "./json";
 export * as recipes from "./recipes";
 export * from "./witness-layout";
-
-export { Byte32, Bytes, BytesVec, CellOutputVec, Uint32LE };

--- a/packages/cobuild/src/witness-layout.ts
+++ b/packages/cobuild/src/witness-layout.ts
@@ -1,22 +1,7 @@
-import { blockchain } from "@ckb-lumos/base";
-import {
-  BytesLike,
-  UnpackResult,
-  bytes,
-  molecule,
-  number,
-} from "@ckb-lumos/codec";
+import { BytesLike, UnpackResult, bytes, molecule } from "@ckb-lumos/codec";
 
-const { Uint32LE } = number;
+import { Bytes, Byte32, Uint32LE, WitnessArgs } from "./builtins";
 const { table, union, vector } = molecule;
-const {
-  /** @group Molecule Codecs */
-  WitnessArgs,
-  Bytes,
-  Byte32,
-} = blockchain;
-
-export { WitnessArgs };
 
 /** @group Molecule Codecs */
 export const Action = table(
@@ -73,17 +58,21 @@ export const WitnessLayout = union(
 );
 
 /** @group Molecule Unpack Result */
-export type ActionUnpackResult = UnpackResult<typeof Action>;
+export type Action = UnpackResult<typeof Action>;
 /** @group Molecule Unpack Result */
-export type MessageUnpackResult = UnpackResult<typeof Message>;
+export type ActionVec = UnpackResult<typeof ActionVec>;
 /** @group Molecule Unpack Result */
-export type SighashAllUnpackResult = UnpackResult<typeof SighashAll>;
+export type Message = UnpackResult<typeof Message>;
 /** @group Molecule Unpack Result */
-export type SighashAllOnlyUnpackResult = UnpackResult<typeof SighashAllOnly>;
+export type SighashAll = UnpackResult<typeof SighashAll>;
 /** @group Molecule Unpack Result */
-export type WitnessLayoutUnpackResult = UnpackResult<typeof WitnessLayout>;
+export type SighashAllOnly = UnpackResult<typeof SighashAllOnly>;
 /** @group Molecule Unpack Result */
-export type WitnessArgsUnpackResult = UnpackResult<typeof WitnessArgs>;
+export type Otx = UnpackResult<typeof Otx>;
+/** @group Molecule Unpack Result */
+export type OtxStart = UnpackResult<typeof OtxStart>;
+/** @group Molecule Unpack Result */
+export type WitnessLayout = UnpackResult<typeof WitnessLayout>;
 
 /**
  * Parse the witness type from the first 4 bytes.
@@ -117,9 +106,8 @@ export function parseWitnessType(
 }
 
 export type ParseWitnessResult =
-  | WitnessLayoutUnpackResult
-  | { type: "WitnessArgs"; value: WitnessArgsUnpackResult };
-
+  | WitnessLayout
+  | { type: "WitnessArgs"; value: WitnessArgs };
 /**
  * Try to parse the witness as WitnessLayout or WitnessArgs.
  *


### PR DESCRIPTION
Name unpack result same name as codec.

- Move all codecs in `@ckb-lumos/codec` to a module `builtins`.
- Name all unpack result types using the same name as the codec itself.

Example:

```
export type BuildingPacket = UnpackResult<typeof BuildingPacket>;
```