### PR TITLE
:tada: PoC of a new molecule codec

### DIFF
--- a/packages/cobuild/README.md
+++ b/packages/cobuild/README.md
@@ -8,3 +8,9 @@ Basic data structures and help functions.
 ## Browser Compatibility
 
 This library uses `TextEncoder` which is [available in most browsers](https://caniuse.com/textencoder). To support old browser, consider a polyfill like [fast-text-encoding](https://github.com/samthor/fast-text-encoding).
+
+## Useful Projects
+
+Here is a list of projects that are recommended to be used together.
+
+- [Immer](https://immerjs.github.io/immer/): for immutable building packet.

--- a/packages/molecule/.eslintrc.js
+++ b/packages/molecule/.eslintrc.js
@@ -1,0 +1,5 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@repo/eslint-config/library.js"],
+};

--- a/packages/molecule/README.md
+++ b/packages/molecule/README.md
@@ -1,0 +1,15 @@
+# `@ckb-cobuild/molecule`
+
+An opinionated [molecule](https://github.com/nervosnetwork/molecule) library which defines schema in code.
+
+- [API Docs](https://ckb-cobuild-docs.vercel.app/api/modules/_ckb_cobuild_molecule.html)
+- [NPM Package](https://www.npmjs.com/package/@ckb-cobuild/molecule)
+
+## Compare With `@ckb-lumos/codec`
+
+The differences between `@ckb-cobuild/molecule` and `@ckb-lumos/codec`:
+
+- Lumos is flexible on the parameter type of the `pack` function, this library is strict and provides `parse` to preprocess the input first.
+- Lumos table codec fields are nullable, this library only allows null for option field.
+- This library supports schema validation via `parse` and `safeParse`.
+- This library supports exporting molecule schema to `.mol` file.

--- a/packages/molecule/jest.config.js
+++ b/packages/molecule/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/molecule/package.json
+++ b/packages/molecule/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@ckb-cobuild/molecule",
+  "version": "0.0.1",
+  "private": false,
+  "homepage": "https://github.com/doitian/ckb-cobuild-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doitian/ckb-cobuild-js.git"
+  },
+  "license": "MIT",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "echo tsup --clean",
+    "clean": "rm -rf node_modules dist .turbo",
+    "dev": "echo tsup --watch",
+    "lint": "eslint . --max-warnings 0",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "tsup-patcher",
+    "postpublish": "mv -f package.json.bak package.json"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "dts": true,
+    "sourcemap": true
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/tsup-patcher": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
+  }
+}

--- a/packages/molecule/src/__tests__/core.test.ts
+++ b/packages/molecule/src/__tests__/core.test.ts
@@ -1,0 +1,36 @@
+import { mol } from "../";
+
+describe("byte", () => {
+  describe(".safeParse", () => {
+    test("(1)", () => {
+      const result = mol.byte.safeParse(1);
+      expect(result).toEqual({
+        success: true,
+        data: 1,
+      });
+    });
+
+    test.each([-1, 1.1, 256])("(%p)", (input) => {
+      const result = mol.byte.safeParse(input);
+      expect(result.success).toBeFalsy();
+      if (!result.success) {
+        expect(result.error.toString()).toMatch(
+          `Expected integer from 0 to 255, found ${input}`,
+        );
+      }
+    });
+  });
+
+  describe(".parse", () => {
+    test("(1)", () => {
+      const result = mol.byte.parse(1);
+      expect(result).toEqual(1);
+    });
+
+    test.each([-1, 1.1, 256])("(%p)", (input) => {
+      expect(() => {
+        mol.byte.parse(input);
+      }).toThrow(`Expected integer from 0 to 255, found ${input}`);
+    });
+  });
+});

--- a/packages/molecule/src/__tests__/error.test.ts
+++ b/packages/molecule/src/__tests__/error.test.ts
@@ -1,0 +1,30 @@
+import { CodecIssue } from "..";
+
+test("collectMessages", () => {
+  const issue = CodecIssue.create("Root", [
+    ["child1", CodecIssue.create("Child 1")],
+    [
+      "child2",
+      CodecIssue.create("Child 2", [
+        ["child3", CodecIssue.create("Child 3")],
+        // empty message are ignored
+        ["child4", CodecIssue.create()],
+      ]),
+    ],
+    [
+      "child5",
+      CodecIssue.create().addChildren([
+        ["child6", CodecIssue.create("Child 6")],
+      ]),
+    ],
+  ]);
+
+  const messages = issue.collectMessages();
+  expect(messages).toEqual([
+    "//: Root",
+    "//child1: Child 1",
+    "//child2: Child 2",
+    "//child2/child3: Child 3",
+    "//child5/child6: Child 6",
+  ]);
+});

--- a/packages/molecule/src/binary-writer.ts
+++ b/packages/molecule/src/binary-writer.ts
@@ -1,0 +1,27 @@
+const EMPTY_BUFFER = new Uint8Array();
+
+export class BinaryWriter {
+  blocks: Uint8Array[] = [];
+  length: number = 0;
+
+  push(block: Uint8Array) {
+    this.blocks.push(block);
+    this.length += block.length;
+  }
+
+  getResultBuffer() {
+    if (this.blocks.length > 1) {
+      const flat = new Uint8Array(this.length);
+      this.blocks.reduce((offset, block) => {
+        flat.set(block, offset);
+        return offset + block.length;
+      }, 0);
+      this.blocks = [flat];
+      return flat;
+    }
+
+    return this.blocks[0] ?? EMPTY_BUFFER;
+  }
+}
+
+export default BinaryWriter;

--- a/packages/molecule/src/codec.ts
+++ b/packages/molecule/src/codec.ts
@@ -1,0 +1,165 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import BinaryWriter from "./binary-writer";
+import { SafeParseReturnType } from "./error";
+
+export abstract class Codec<T, TParseInput = T> {
+  /**
+   * Name of this codec used to export .mol file.
+   */
+  readonly name: string;
+
+  /**
+   * The byte length of a fixed size molecule type.
+   * @see [Molecule Encoding Spec](https://github.com/nervosnetwork/molecule/blob/master/docs/encoding_spec.md)
+   */
+  readonly fixedByteLength?: number;
+
+  constructor(name: string, fixedByteLength?: number) {
+    this.name = name;
+    this.fixedByteLength = fixedByteLength;
+  }
+
+  /**
+   * Unpack the value from the molecule buffer.
+   */
+  abstract unpack(buffer: Uint8Array): T;
+
+  /**
+   * Pack the value and append the buffer to the provided writer.
+   *
+   * Take the advantage of writer and append the buffer as blocks. The writer can concatenate all blocks into one buffer for the final result.
+   */
+  abstract packTo(value: T, writer: BinaryWriter): void;
+
+  /**
+   * Parse a compatible input. Return a result instead of throwing.
+   * @see {@link parse}
+   */
+  abstract safeParse(input: TParseInput): SafeParseReturnType<T>;
+
+  /**
+   * Get the schema specification of this codec as in the `.mol` file.
+   */
+  getSchema(): string {
+    return "";
+  }
+
+  /**
+   * Direct dependencies of this codec.
+   */
+  getDepedencies(): Iterable<UnknownCodec> {
+    return [];
+  }
+
+  /**
+   * Export the schema of this codec and all the dependencies into the map.
+   *
+   * The order of the map is guaranteed that the dependency is always exported before the dependent.
+   */
+  exportSchema(exported: Map<string, string>) {
+    for (const dep of this.getDepedencies()) {
+      dep.exportSchema(exported);
+    }
+    if (!exported.has(this.name)) {
+      const schema = this.getSchema();
+      if (schema !== "") {
+        exported.set(this.name, schema);
+      }
+    }
+  }
+
+  /**
+   * Pack value into a molecule buffer.
+   *
+   * @see {@link packTo}
+   */
+  pack(value: T): Uint8Array {
+    const writer = new BinaryWriter();
+    this.packTo(value, writer);
+    return writer.getResultBuffer();
+  }
+
+  /**
+   * Parse a compatible input.
+   * @throws {TParseError}
+   */
+  parse(input: TParseInput): T {
+    const result = this.safeParse(input);
+    if (result.success) {
+      return result.data;
+    }
+    throw result.error;
+  }
+
+  /**
+   * Create a new codec which `parse` will call the preprocess function first.
+   */
+  preprocess<TOutterParseInput>(
+    preprocess: (input: TOutterParseInput) => SafeParseReturnType<TParseInput>,
+  ) {
+    return new ParseCodec(this, preprocess);
+  }
+}
+
+export type UnknownCodec = Codec<unknown, unknown>;
+export type AnyCodec = Codec<any, any>;
+
+/**
+ * Given a codec type, infer the JavaScript type.
+ *
+ * @example
+ * ```ts
+ * import { mol } from "@ckb-cobuild/molecule";
+ * const flag: mol.Infer<typeof mol.byte> = mol.byte.parse(1);
+ * ```
+ */
+export type Infer<TCodec> = TCodec extends Codec<infer T, any> ? T : never;
+export type InferParseInput<TCodec> = TCodec extends Codec<
+  any,
+  infer TParseInput
+>
+  ? TParseInput
+  : never;
+
+export class ParseCodec<T, TParseInput, TInnerParseInput> extends Codec<
+  T,
+  TParseInput
+> {
+  private _inner: Codec<T, TInnerParseInput>;
+  private _preprocess: (
+    input: TParseInput,
+  ) => SafeParseReturnType<TInnerParseInput>;
+
+  constructor(
+    inner: Codec<T, TInnerParseInput>,
+    preprocess: (input: TParseInput) => SafeParseReturnType<TInnerParseInput>,
+  ) {
+    super(inner.name, inner.fixedByteLength);
+    this._inner = inner;
+    this._preprocess = preprocess;
+  }
+
+  safeParse(input: TParseInput): SafeParseReturnType<T> {
+    const result = this._preprocess(input);
+    if (result.success) {
+      return this._inner.safeParse(result.data);
+    }
+    return result;
+  }
+
+  unpack(buffer: Uint8Array): T {
+    return this._inner.unpack(buffer);
+  }
+
+  packTo(value: T, writer: BinaryWriter) {
+    return this._inner.packTo(value, writer);
+  }
+
+  getSchema(): string {
+    return this._inner.getSchema();
+  }
+
+  getDepedencies(): Iterable<UnknownCodec> {
+    return this._inner.getDepedencies();
+  }
+}

--- a/packages/molecule/src/core/byte.ts
+++ b/packages/molecule/src/core/byte.ts
@@ -1,0 +1,46 @@
+import { Codec } from "../codec";
+import BinaryWriter from "../binary-writer";
+import { CodecError, SafeParseReturnType } from "../error";
+
+/**
+ * @internal
+ */
+export class ByteCodec extends Codec<number> {
+  constructor() {
+    super("byte", 1);
+  }
+
+  unpack(buffer: Uint8Array): number {
+    return buffer[0]!;
+  }
+
+  packTo(value: number, writer: BinaryWriter) {
+    writer.push(this.pack(value));
+  }
+
+  pack(value: number): Uint8Array {
+    return new Uint8Array([value]);
+  }
+
+  safeParse(input: number): SafeParseReturnType<number> {
+    if (Number.isInteger(input) && input >= 0 && input <= 255) {
+      return {
+        success: true,
+        data: input,
+      };
+    }
+
+    return {
+      success: false,
+      error: CodecError.create(
+        `Expected integer from 0 to 255, found ${input}`,
+      ),
+    };
+  }
+}
+
+/**
+ * Codec for the molecule primitive type `byte`.
+ * @group Core Codecs
+ */
+export const byte = new ByteCodec();

--- a/packages/molecule/src/core/index.ts
+++ b/packages/molecule/src/core/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Codecs for molecule core tyeps.
+ * @module
+ */
+export * from "./byte";

--- a/packages/molecule/src/error.ts
+++ b/packages/molecule/src/error.ts
@@ -1,0 +1,101 @@
+export type SafeParseReturnSuccess<T> = {
+  success: true;
+  data: T;
+};
+export type SafeParseReturnError = {
+  success: false;
+  error: CodecError;
+};
+export type SafeParseReturnType<T> =
+  | SafeParseReturnSuccess<T>
+  | SafeParseReturnError;
+
+export function formatCodecError(path: (string | number)[], message: string) {
+  return `//${path.join("/")}: ${message}`;
+}
+export type CodecErrorFormatter = typeof formatCodecError;
+
+export const PARSE_ROOT_PATH = "//";
+
+export class CodecIssue {
+  message?: string = undefined;
+  children?: Map<string | number, CodecIssue> = undefined;
+
+  constructor(message: string | undefined = undefined) {
+    this.message = message;
+  }
+
+  static create(
+    message: string | undefined = undefined,
+    children?: Iterable<[string | number, CodecIssue]>,
+  ): CodecIssue {
+    const issue = new CodecIssue(message);
+    if (children) {
+      issue.addChildren(children);
+    }
+    return issue;
+  }
+
+  addChild(key: string | number, issue: CodecIssue): CodecIssue {
+    if (!this.children) {
+      this.children = new Map();
+    }
+    this.children.set(key, issue);
+    return this;
+  }
+
+  addChildren(children: Iterable<[string | number, CodecIssue]>): CodecIssue {
+    if (!this.children) {
+      this.children = new Map();
+    }
+    for (const [key, issue] of children) {
+      this.children.set(key, issue);
+    }
+    return this;
+  }
+
+  collectMessages(formatter?: CodecErrorFormatter) {
+    const _formatter = formatter ?? formatCodecError;
+    const messages: string[] = [];
+    this.collectMessagesIn(messages, [], _formatter);
+    return messages;
+  }
+
+  collectMessagesIn(
+    messages: string[],
+    prefix: (string | number)[],
+    formatter: CodecErrorFormatter,
+  ) {
+    if (this.message) {
+      messages.push(formatter(prefix, this.message));
+    }
+    if (this.children && this.children.size > 0) {
+      const pathIndex = prefix.length;
+      for (const [key, issue] of this.children) {
+        prefix[pathIndex] = key;
+        issue.collectMessagesIn(messages, prefix, formatter);
+      }
+      prefix.pop();
+    }
+
+    return;
+  }
+}
+
+export class CodecError extends Error {
+  issue: CodecIssue;
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.issue = CodecIssue.create(message);
+    this.name = "CodecError";
+  }
+
+  static create(message: string, options?: ErrorOptions): CodecError {
+    return new CodecError(message, options);
+  }
+
+  collectMessages(formatter?: CodecErrorFormatter): string[] {
+    return this.issue.collectMessages(formatter);
+  }
+}

--- a/packages/molecule/src/externals.ts
+++ b/packages/molecule/src/externals.ts
@@ -1,0 +1,4 @@
+export * from "./codec";
+export * from "./core";
+export * from "./error";
+export * from "./binary-writer";

--- a/packages/molecule/src/index.ts
+++ b/packages/molecule/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./externals";
+import * as mol from "./externals";
+
+export { mol };
+export default mol;

--- a/packages/molecule/tsconfig.json
+++ b/packages/molecule/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/molecule/typedoc.json
+++ b/packages/molecule/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "includeVersion": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,27 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
 
+  packages/molecule:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/tsup-patcher':
+        specifier: workspace:*
+        version: link:../tsup-patcher
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/jest':
+        specifier: ^29.5.11
+        version: 29.5.11
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
+
   packages/tsup-patcher: {}
 
   packages/typescript-config: {}
@@ -201,7 +222,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.9
+      '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
   /@babel/code-frame@7.22.13:
@@ -373,6 +394,7 @@ packages:
   /@babel/parser@7.23.3:
     resolution: {integrity: sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
     dependencies:
       '@babel/types': 7.23.3
     dev: true
@@ -2510,6 +2532,7 @@ packages:
   /browserslist@4.22.1:
     resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001563
       electron-to-chromium: 1.4.583
@@ -3178,7 +3201,7 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.22.3
       es-set-tostringtag: 2.0.2
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       get-intrinsic: 1.2.2
       globalthis: 1.0.3
       has-property-descriptors: 1.0.1
@@ -3326,7 +3349,7 @@ packages:
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.11.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.54.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
-      is-core-module: 2.12.0
+      is-core-module: 2.13.1
       is-glob: 4.0.3
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -3693,6 +3716,7 @@ packages:
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
+    hasBin: true
     dev: true
 
   /esquery@1.5.0:
@@ -3937,10 +3961,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -4203,13 +4223,6 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
-  /has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
-    dependencies:
-      function-bind: 1.1.1
-    dev: true
-
   /hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
     engines: {node: '>= 0.4'}
@@ -4440,12 +4453,6 @@ packages:
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /is-core-module@2.12.0:
-    resolution: {integrity: sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==}
-    dependencies:
-      has: 1.0.3
     dev: true
 
   /is-core-module@2.13.1:
@@ -5199,16 +5206,19 @@ packages:
 
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
+    hasBin: true
     dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
+    hasBin: true
     dev: true
 
   /jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
+    hasBin: true
     dev: true
 
   /json-parse-even-better-errors@2.3.1:
@@ -5651,7 +5661,7 @@ packages:
       isbinaryfile: 4.0.10
       lodash.get: 4.4.2
       mkdirp: 0.5.6
-      resolve: 1.22.2
+      resolve: 1.22.8
     dev: true
 
   /node-releases@2.0.13:
@@ -6303,20 +6313,13 @@ packages:
   /resolve@1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
-      is-core-module: 2.12.0
+      is-core-module: 2.13.1
       path-parse: 1.0.7
-    dev: true
-
-  /resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
-    dependencies:
-      is-core-module: 2.12.0
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+    hasBin: true
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
@@ -6325,6 +6328,7 @@ packages:
 
   /resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
+    hasBin: true
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7

--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -5,6 +5,7 @@ const config = {
   entryPoints: [],
   entryPointStrategy: "packages",
   plugin: ["typedoc-plugin-missing-exports"],
+  groupOrder: ["Core Codecs", "*"],
   out: "apps/docs/public/api/",
 };
 


### PR DESCRIPTION
The PoC only contains a `byte` codec.

The differences between `@ckb-cobuild/molecule` and `@ckb-lumos/codec`:

- Lumos is flexible on the parameter type of the `pack` function, this library is strict and provides `parse` to preprocess the input first.
- Lumos table codec fields are nullable, this library only allows null for option field.
- This library supports schema validation via `parse` and `safeParse`.
- This library supports exporting molecule schema to `.mol` file.