### PR TITLE
:sparkles: Add @ckb-cobuild/hex-encoding

### DIFF
--- a/.changeset/wise-mails-grab.md
+++ b/.changeset/wise-mails-grab.md
@@ -1,0 +1,7 @@
+---
+"@ckb-cobuild/hex-encoding": major
+---
+
+:sparkles: Add @ckb-cobuild/hex-encoding
+
+Port of the Go [encoding/hex](https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go) and copy from [Deno](https://github.com/denoland/deno_std/blob/main/encoding/hex.ts).

--- a/packages/hex-encoding/.eslintrc.js
+++ b/packages/hex-encoding/.eslintrc.js
@@ -1,0 +1,5 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@repo/eslint-config/library.js"],
+};

--- a/packages/hex-encoding/README.md
+++ b/packages/hex-encoding/README.md
@@ -1,0 +1,10 @@
+# `@ckb-cobuild/hex-encoding`
+
+Port of the Go [encoding/hex](https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go) and copy from [Deno](https://github.com/denoland/deno_std/blob/main/encoding/hex.ts).
+
+- [API Docs](https://ckb-cobuild-docs.vercel.app/api/modules/_ckb_cobuild_hex_encoding.html)
+- [NPM Package](https://www.npmjs.com/package/@ckb-cobuild/hex-encoding)
+
+## Browser Compatibility
+
+- `TextEncoder`: [Can I Use?](https://caniuse.com/textencoder), Polyfill: [fast-text-encoding](https://github.com/samthor/fast-text-encoding).

--- a/packages/hex-encoding/jest.config.js
+++ b/packages/hex-encoding/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/hex-encoding/package.json
+++ b/packages/hex-encoding/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@ckb-cobuild/hex-encoding",
+  "version": "0.0.0",
+  "homepage": "https://github.com/doitian/ckb-cobuild-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doitian/ckb-cobuild-js.git"
+  },
+  "license": "MIT",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsup --clean",
+    "clean": "rm -rf node_modules dist .turbo coverage",
+    "coverage": "jest --coverage --coverageReporters lcov",
+    "lint": "eslint . --max-warnings 0",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "tsup-patcher",
+    "postpublish": "mv -f package.json.bak package.json"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "dts": true,
+    "sourcemap": true
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/tsup-patcher": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.20",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.0.1"
+  }
+}

--- a/packages/hex-encoding/src/__tests__/index.test.ts
+++ b/packages/hex-encoding/src/__tests__/index.test.ts
@@ -1,0 +1,65 @@
+// Ported from Go
+// https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// https://github.com/denoland/deno_std/blob/main/encoding/hex_test.ts
+
+import { decodeHex, encodeHex } from "../";
+
+const testCases = [
+  // encoded(hex) / decoded(Uint8Array)
+  ["", []],
+  ["0001020304050607", [0, 1, 2, 3, 4, 5, 6, 7]],
+  ["08090a0b0c0d0e0f", [8, 9, 10, 11, 12, 13, 14, 15]],
+  ["f0f1f2f3f4f5f6f7", [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7]],
+  ["f8f9fafbfcfdfeff", [0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff]],
+  ["67", Array.from(new TextEncoder().encode("g"))],
+  ["e3a1", [0xe3, 0xa1]],
+];
+
+const errCases: [string, ErrorConstructor, string][] = [
+  // encoded(hex) / error / msg
+  ["0", RangeError, ""],
+  ["zd4aa", TypeError, "'z'"],
+  ["d4aaz", TypeError, "'z'"],
+  ["30313", RangeError, ""],
+  ["0g", TypeError, "'g'"],
+  ["00gg", TypeError, "'g'"],
+  ["0\x01", TypeError, "'\x01'"],
+  ["ffeed", RangeError, ""],
+];
+
+describe("encodeHex()", () => {
+  test("handles string", () => {
+    const srcStr = "abc";
+    const dest = encodeHex(srcStr);
+    expect(dest).toEqual("616263");
+  });
+
+  test.each(testCases)("into %s", (enc, dec) => {
+    const src = new Uint8Array(dec as number[]);
+    const dest = encodeHex(src);
+    expect(dest.length).toEqual(src.length * 2);
+    expect(dest).toEqual(enc);
+  });
+});
+
+describe("decodeHex()", () => {
+  // Case for decoding uppercase hex characters, since
+  // Encode always uses lowercase.
+  const extraTestcase: [string, number[]][] = [
+    ["F8F9FAFBFCFDFEFF", [0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff]],
+  ];
+
+  test.each(testCases.concat(extraTestcase))("from %s", (enc, dec) => {
+    const dest = decodeHex(enc as string);
+    expect(dest).toEqual(new Uint8Array(dec as number[]));
+  });
+
+  test.each(errCases)("throws on %s", (input, expectedErr, msg) => {
+    expect(() => decodeHex(input)).toThrow(expectedErr);
+    expect(() => decodeHex(input)).toThrow(msg);
+  });
+});

--- a/packages/hex-encoding/src/index.ts
+++ b/packages/hex-encoding/src/index.ts
@@ -1,0 +1,132 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// https://github.com/golang/go/blob/master/LICENSE
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+// https://github.com/denoland/deno_std/blob/main/encoding/hex.ts
+
+/**
+ * Port of the Go
+ * {@link https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go | encoding/hex}
+ * library.
+ *
+ * This module is browser compatible.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   decodeHex,
+ *   encodeHex,
+ * } from "@ckb-cobuild/hex-encoding";
+ *
+ * const binary = new TextEncoder().encode("abc");
+ * const encoded = encodeHex(binary);
+ * console.log(encoded);
+ * // => "616263"
+ *
+ * console.log(decodeHex(encoded));
+ * // => Uint8Array(3) [ 97, 98, 99 ]
+ * ```
+ *
+ * @module
+ */
+const hexTable = new TextEncoder().encode("0123456789abcdef");
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function getTypeName(value: unknown): string {
+  const type = typeof value;
+  if (type !== "object") {
+    return type;
+  } else if (value === null) {
+    return "null";
+  } else {
+    return value?.constructor?.name ?? "object";
+  }
+}
+
+function validateBinaryLike(source: unknown): Uint8Array {
+  if (typeof source === "string") {
+    return textEncoder.encode(source);
+  } else if (source instanceof Uint8Array) {
+    return source;
+  } else if (source instanceof ArrayBuffer) {
+    return new Uint8Array(source);
+  }
+  throw new TypeError(
+    `The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type ${getTypeName(
+      source,
+    )}.`,
+  );
+}
+
+function errInvalidByte(byte: number) {
+  return new TypeError(`Invalid byte '${String.fromCharCode(byte)}'`);
+}
+
+function errLength() {
+  return new RangeError("Odd length hex string");
+}
+
+/** Converts a hex character into its value. */
+function fromHexChar(byte: number): number {
+  // '0' <= byte && byte <= '9'
+  if (48 <= byte && byte <= 57) return byte - 48;
+  // 'a' <= byte && byte <= 'f'
+  if (97 <= byte && byte <= 102) return byte - 97 + 10;
+  // 'A' <= byte && byte <= 'F'
+  if (65 <= byte && byte <= 70) return byte - 65 + 10;
+
+  throw errInvalidByte(byte);
+}
+
+/**
+ * Converts data into a hex-encoded string.
+ *
+ * @example
+ * ```ts
+ * import { encodeHex } from "@ckb-cobuild/hex-encoding";
+ *
+ * encodeHex("abc"); // "616263"
+ * ```
+ */
+export function encodeHex(src: string | Uint8Array | ArrayBuffer): string {
+  const u8 = validateBinaryLike(src);
+
+  const dst = new Uint8Array(u8.length * 2);
+  for (let i = 0; i < dst.length; i++) {
+    const v = u8[i]!;
+    dst[i * 2] = hexTable[v >> 4]!;
+    dst[i * 2 + 1] = hexTable[v & 0x0f]!;
+  }
+  return textDecoder.decode(dst);
+}
+
+/**
+ * Decodes the given hex-encoded string. If the input is malformed, an error is
+ * thrown.
+ *
+ * @example
+ * ```ts
+ * import { decodeHex } from "https://deno.land/std@$STD_VERSION/encoding/hex.ts";
+ *
+ * decodeHex("616263"); // Uint8Array(3) [ 97, 98, 99 ]
+ * ```
+ */
+export function decodeHex(src: string): Uint8Array {
+  const u8 = textEncoder.encode(src);
+  const dst = new Uint8Array(u8.length / 2);
+  for (let i = 0; i < dst.length; i++) {
+    const a = fromHexChar(u8[i * 2]!);
+    const b = fromHexChar(u8[i * 2 + 1]!);
+    dst[i] = (a << 4) | b;
+  }
+
+  if (u8.length % 2 === 1) {
+    // Check for invalid char before reporting bad length,
+    // since the invalid char (if present) is an earlier problem.
+    fromHexChar(u8[dst.length * 2]!);
+    throw errLength();
+  }
+
+  return dst;
+}

--- a/packages/hex-encoding/tsconfig.json
+++ b/packages/hex-encoding/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/hex-encoding/typedoc.json
+++ b/packages/hex-encoding/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "includeVersion": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 10.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@20.11.20)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
@@ -131,6 +131,33 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
 
+  packages/hex-encoding:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/tsup-patcher':
+        specifier: workspace:*
+        version: link:../tsup-patcher
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/jest':
+        specifier: ^29.5.11
+        version: 29.5.11
+      '@types/node':
+        specifier: ^20.11.20
+        version: 20.11.20
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.11.20)
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.0.1(typescript@5.2.2)
+
   packages/library-template:
     devDependencies:
       '@repo/eslint-config':
@@ -147,7 +174,7 @@ importers:
         version: 29.5.11
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@20.11.20)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
@@ -168,7 +195,7 @@ importers:
         version: 29.5.11
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@20.11.20)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
@@ -1123,7 +1150,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -1144,14 +1171,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.5.2)
+      jest-config: 29.7.0(@types/node@20.11.20)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -1179,7 +1206,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       jest-mock: 29.7.0
     dev: true
 
@@ -1206,7 +1233,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -1239,7 +1266,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.20
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -1327,7 +1354,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -1759,13 +1786,13 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
     dev: true
 
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
     dev: true
 
   /@types/inquirer@6.5.0:
@@ -1832,6 +1859,12 @@ packages:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
     dev: true
 
+  /@types/node@20.11.20:
+    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
   /@types/node@20.5.2:
     resolution: {integrity: sha512-5j/lXt7unfPOUlrKC34HIaedONleyLtwkKggiD/0uuMfT8gg2EOpg0dz4lCD15Ga7muC+1WzJZAjIB9simWd6Q==}
     dev: true
@@ -1873,7 +1906,7 @@ packages:
   /@types/through@0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
     dev: true
 
   /@types/yargs-parser@21.0.3:
@@ -2837,7 +2870,7 @@ packages:
     requiresBuild: true
     dev: true
 
-  /create-jest@29.7.0:
+  /create-jest@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2846,7 +2879,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.5.2)
+      jest-config: 29.7.0(@types/node@20.11.20)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4779,7 +4812,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -4800,7 +4833,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0:
+  /jest-cli@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -4814,10 +4847,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@20.11.20)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.5.2)
+      jest-config: 29.7.0(@types/node@20.11.20)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4828,7 +4861,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@20.5.2):
+  /jest-config@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -4843,7 +4876,7 @@ packages:
       '@babel/core': 7.23.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       babel-jest: 29.7.0(@babel/core@7.23.3)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -4903,7 +4936,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -4919,7 +4952,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4970,7 +5003,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       jest-util: 29.7.0
     dev: true
 
@@ -5025,7 +5058,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5056,7 +5089,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -5108,7 +5141,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5133,7 +5166,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5145,13 +5178,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.5.2
+      '@types/node': 20.11.20
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0:
+  /jest@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -5164,7 +5197,7 @@ packages:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0
+      jest-cli: 29.7.0(@types/node@20.11.20)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -7017,7 +7050,7 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.19.11
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.11.20)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -7313,6 +7346,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /universalify@0.1.2:


### PR DESCRIPTION
Port of the Go [encoding/hex](https://github.com/golang/go/blob/go1.12.5/src/encoding/hex/hex.go) and copy from [Deno](https://github.com/denoland/deno_std/blob/main/encoding/hex.ts).