### PR TITLE
:sparkles: Molecule integer codecs for bigint

### DIFF
--- a/.changeset/new-ducks-tell.md
+++ b/.changeset/new-ducks-tell.md
@@ -1,0 +1,14 @@
+---
+"@ckb-cobuild/molecule-bigint": major
+---
+
+:sparkles: Molecule integer codecs for bigint
+
+```ts
+import { Uint64 } from "@ckb-lumos/molecule-bigint";
+const buffer = Uint64.pack(1n);
+console.log(buffer);
+// => [1, 0, 0, 0, 0, 0, 0, 0],
+console.log(Uint64.unpack(buffer));
+// => 1n
+```

--- a/packages/molecule-bigint/.eslintrc.js
+++ b/packages/molecule-bigint/.eslintrc.js
@@ -1,0 +1,5 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@repo/eslint-config/library.js"],
+};

--- a/packages/molecule-bigint/README.md
+++ b/packages/molecule-bigint/README.md
@@ -1,0 +1,10 @@
+# `@ckb-cobuild/molecule-bigint`
+
+BitInt codecs for `@ckb-cobuild/molecule`.
+
+- [API Docs](https://ckb-cobuild-docs.vercel.app/api/modules/_ckb_cobuild_molecule_bigint.html)
+- [NPM Package](https://www.npmjs.com/package/@ckb-cobuild/molecule-bigint)
+
+## Browser Compatibility
+
+- `BigInt`: [Can I Use?](https://caniuse.com/bigint)

--- a/packages/molecule-bigint/jest.config.js
+++ b/packages/molecule-bigint/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/molecule-bigint/package.json
+++ b/packages/molecule-bigint/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@ckb-cobuild/molecule-bigint",
+  "version": "0.0.0",
+  "homepage": "https://github.com/doitian/ckb-cobuild-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doitian/ckb-cobuild-js.git"
+  },
+  "license": "MIT",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsup --clean",
+    "clean": "rm -rf node_modules dist .turbo coverage",
+    "coverage": "jest --coverage --coverageReporters lcov",
+    "lint": "eslint . --max-warnings 0",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "tsup-patcher",
+    "postpublish": "mv -f package.json.bak package.json"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "dts": true,
+    "sourcemap": true
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/tsup-patcher": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.0.1"
+  },
+  "dependencies": {
+    "@ckb-cobuild/molecule": "workspace:^"
+  }
+}

--- a/packages/molecule-bigint/src/__tests__/index.test.ts
+++ b/packages/molecule-bigint/src/__tests__/index.test.ts
@@ -1,0 +1,108 @@
+import { Uint64, Int64 } from "../";
+import mol from "@ckb-cobuild/molecule";
+
+describe("Uint64", () => {
+  describe(".safeParse", () => {
+    test.each([0n, 0xffffffffffffffffn])("(%s)", (input) => {
+      expect(Uint64.safeParse(input)).toEqual(mol.parseSuccess(input));
+    });
+
+    test.each([0x10000000000000000n])("(%s)", (input) => {
+      expect(Uint64.safeParse(input)).toEqual(
+        mol.parseError(`Expected a valid number for Uint64, got ${input}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: 0n,
+      buffer: [0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: 1n,
+      buffer: [1, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: 0xffffffffffffffffn,
+      buffer: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Uint64.pack(value)).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Uint64.unpack(Uint8Array.from(buffer))).toEqual(value);
+    });
+
+    test("([0])", () => {
+      expect(() => Uint64.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 8, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Uint64.getSchema()).toEqual("array Uint64 [byte; 8];");
+  });
+});
+
+describe("Int64", () => {
+  describe(".safeParse", () => {
+    test.each([-0x8000000000000000n, 0x7fffffffffffffffn])("(%s)", (input) => {
+      expect(Int64.safeParse(input)).toEqual(mol.parseSuccess(input));
+    });
+
+    test.each([-0x8000000000000001n, 0x8000000000000000n])("(%s)", (input) => {
+      expect(Int64.safeParse(input)).toEqual(
+        mol.parseError(`Expected a valid number for Int64, got ${input}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: 0n,
+      buffer: [0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: -0x8000000000000000n,
+      buffer: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
+    },
+    {
+      value: -0x7fffffffffffffffn,
+      buffer: [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
+    },
+    {
+      value: 0x7fffffffffffffffn,
+      buffer: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Int64.pack(value)).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Int64.unpack(Uint8Array.from(buffer))).toEqual(value);
+    });
+
+    test("([0])", () => {
+      expect(() => Int64.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 8, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Int64.getSchema()).toEqual("array Int64 [byte; 8];");
+  });
+});

--- a/packages/molecule-bigint/src/index.ts
+++ b/packages/molecule-bigint/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Number Codecs of 64-bit integers using the native bigint.
+ * @module
+ * @example
+ * ```ts
+ * import { Uint64 } from "@ckb-lumos/molecule-bigint";
+ * const buffer = Uint64.pack(1n);
+ * console.log(buffer);
+ * // => [1, 0, 0, 0, 0, 0, 0, 0],
+ * console.log(Uint64.unpack(buffer));
+ * // => 1n
+ * ```
+ */
+import { NumberCodec } from "@ckb-cobuild/molecule";
+
+export function createBigUint64Codec(
+  name: string,
+  littleEndian: boolean,
+): NumberCodec<bigint> {
+  return new NumberCodec(name, 8, {
+    checkNumber(value) {
+      return value >= 0n && value <= 0xffffffffffffffffn;
+    },
+    packNumberTo(value, buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      view.setBigUint64(0, value, littleEndian);
+    },
+    unpackNumber(buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      return view.getBigUint64(0, littleEndian);
+    },
+  });
+}
+export const Uint64 = createBigUint64Codec("Uint64", true);
+
+export function createBigInt64Codec(
+  name: string,
+  littleEndian: boolean,
+): NumberCodec<bigint> {
+  return new NumberCodec(name, 8, {
+    checkNumber(value) {
+      return value >= -0x8000000000000000n && value <= 0x7fffffffffffffffn;
+    },
+    packNumberTo(value, buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      view.setBigInt64(0, value, littleEndian);
+    },
+    unpackNumber(buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      return view.getBigInt64(0, littleEndian);
+    },
+  });
+}
+export const Int64 = createBigInt64Codec("Int64", true);

--- a/packages/molecule-bigint/tsconfig.json
+++ b/packages/molecule-bigint/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/molecule-bigint/typedoc.json
+++ b/packages/molecule-bigint/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "includeVersion": true
+}

--- a/packages/molecule/README.md
+++ b/packages/molecule/README.md
@@ -5,6 +5,10 @@ An opinionated [molecule](https://github.com/nervosnetwork/molecule) library whi
 - [API Docs](https://ckb-cobuild-docs.vercel.app/api/modules/_ckb_cobuild_molecule.html)
 - [NPM Package](https://www.npmjs.com/package/@ckb-cobuild/molecule)
 
+## More Codecs
+
+- `@ckb-cobuild/molecule-bigint`: 64-bit integer codecs for native bigint.
+
 ## Browser Compatibility
 
 - `TypedArray`: [Can I Use?](https://caniuse.com/mdn-javascript_builtins_typedarray)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,34 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1(typescript@5.2.2)
 
+  packages/molecule-bigint:
+    dependencies:
+      '@ckb-cobuild/molecule':
+        specifier: workspace:^
+        version: link:../molecule
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/tsup-patcher':
+        specifier: workspace:*
+        version: link:../tsup-patcher
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/jest':
+        specifier: ^29.5.11
+        version: 29.5.11
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.11.20)
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.0.1(typescript@5.2.2)
+
   packages/tsup-patcher: {}
 
   packages/typescript-config: {}


### PR DESCRIPTION
 ```ts
 import { Uint64 } from "@ckb-lumos/molecule-bigint";
 const buffer = Uint64.pack(1n);
 console.log(buffer);
 // => [1, 0, 0, 0, 0, 0, 0, 0],
 console.log(Uint64.unpack(buffer));
 // => 1n
 ```