### PR TITLE
:sparkles: Molecule integer codecs for JSBI

### DIFF
--- a/.changeset/curly-melons-hope.md
+++ b/.changeset/curly-melons-hope.md
@@ -1,0 +1,15 @@
+---
+"@ckb-cobuild/molecule-jsbi": major
+---
+
+:sparkles: Molecule integer codecs for bigint (#20)
+
+```ts
+import { Uint64 } from "@ckb-lumos/molecule-jsbi";
+import JSBI from "jsbi";
+const buffer = Uint64.pack(JSBI.BigInt(1));
+console.log(buffer);
+// => [1, 0, 0, 0, 0, 0, 0, 0],
+console.log(JSBI.toNumber(Uint64.unpack(buffer)));
+// => 1
+```

--- a/packages/molecule-jsbi/.eslintrc.js
+++ b/packages/molecule-jsbi/.eslintrc.js
@@ -1,0 +1,5 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@repo/eslint-config/library.js"],
+};

--- a/packages/molecule-jsbi/README.md
+++ b/packages/molecule-jsbi/README.md
@@ -1,0 +1,6 @@
+# `@ckb-cobuild/molecule-jsbi`
+
+[JSBI](https://github.com/GoogleChromeLabs/jsbi) codecs for `@ckb-cobuild/molecule`.
+
+- [API Docs](https://ckb-cobuild-docs.vercel.app/api/modules/_ckb_cobuild_molecule_jsbi.html)
+- [NPM Package](https://www.npmjs.com/package/@ckb-cobuild/molecule-jsbi)

--- a/packages/molecule-jsbi/jest.config.js
+++ b/packages/molecule-jsbi/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/molecule-jsbi/package.json
+++ b/packages/molecule-jsbi/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@ckb-cobuild/molecule-jsbi",
+  "version": "0.0.0",
+  "homepage": "https://github.com/doitian/ckb-cobuild-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doitian/ckb-cobuild-js.git"
+  },
+  "license": "MIT",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsup --clean",
+    "clean": "rm -rf node_modules dist .turbo coverage",
+    "coverage": "jest --coverage --coverageReporters lcov",
+    "lint": "eslint . --max-warnings 0",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "tsup-patcher",
+    "postpublish": "mv -f package.json.bak package.json"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "dts": true,
+    "sourcemap": true
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/tsup-patcher": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.0.1"
+  },
+  "dependencies": {
+    "@ckb-cobuild/molecule": "workspace:^",
+    "jsbi": "^4.3.0"
+  }
+}

--- a/packages/molecule-jsbi/src/__tests__/index.test.ts
+++ b/packages/molecule-jsbi/src/__tests__/index.test.ts
@@ -1,0 +1,622 @@
+import JSBI from "jsbi";
+import {
+  makeJSBI,
+  Uint64,
+  Int64,
+  Uint128,
+  Int128,
+  Uint256,
+  Int256,
+  packUintN,
+  unpackUintN,
+} from "../";
+import mol from "@ckb-cobuild/molecule";
+
+describe("Uint64", () => {
+  describe(".safeParse", () => {
+    test.each(["0", "0xffffffffffffffff"])("(%s)", (input) => {
+      const jsbi = JSBI.BigInt(input);
+      expect(Uint64.safeParse(jsbi)).toEqual(mol.parseSuccess(jsbi));
+    });
+
+    test.each(["0x10000000000000000"])("(%s)", (input) => {
+      const jsbi = JSBI.BigInt(input);
+      expect(Uint64.safeParse(jsbi)).toEqual(
+        mol.parseError(`Expected a valid number for Uint64, got ${jsbi}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: "0",
+      buffer: [0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: "1",
+      buffer: [1, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: "0xffffffffffffffff",
+      buffer: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Uint64.pack(JSBI.BigInt(value))).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Uint64.unpack(Uint8Array.from(buffer))).toEqual(
+        JSBI.BigInt(value),
+      );
+    });
+
+    test("([0])", () => {
+      expect(() => Uint64.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 8, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Uint64.getSchema()).toEqual("array Uint64 [byte; 8];");
+  });
+});
+
+describe("Int64", () => {
+  describe(".safeParse", () => {
+    test.each(["-0x8000000000000000", "0x7fffffffffffffff"])(
+      "(%s)",
+      (input) => {
+        const jsbi = makeJSBI(input);
+        expect(Int64.safeParse(jsbi)).toEqual(mol.parseSuccess(jsbi));
+      },
+    );
+
+    test.each(["-0x8000000000000001", "0x8000000000000000"])(
+      "(%s)",
+      (input) => {
+        const jsbi = makeJSBI(input);
+        expect(Int64.safeParse(jsbi)).toEqual(
+          mol.parseError(`Expected a valid number for Int64, got ${jsbi}`),
+        );
+      },
+    );
+  });
+
+  const cases = [
+    {
+      value: "0",
+      buffer: [0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: "-0x8000000000000000",
+      buffer: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
+    },
+    {
+      value: "-0x7fffffffffffffff",
+      buffer: [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
+    },
+    {
+      value: "0x7fffffffffffffff",
+      buffer: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Int64.pack(makeJSBI(value))).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Int64.unpack(Uint8Array.from(buffer))).toEqual(makeJSBI(value));
+    });
+
+    test("([0])", () => {
+      expect(() => Int64.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 8, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Int64.getSchema()).toEqual("array Int64 [byte; 8];");
+  });
+});
+
+describe("Uint128", () => {
+  describe(".safeParse", () => {
+    test.each(["0", "0xffffffffffffffffffffffffffffffff"])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Uint128.safeParse(makeJSBI(jsbi))).toEqual(mol.parseSuccess(jsbi));
+    });
+
+    test.each(["0x1000000000000000000000000000000000"])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Uint128.safeParse(jsbi)).toEqual(
+        mol.parseError(`Expected a valid number for Uint128, got ${jsbi}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: "0",
+      buffer: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: "1",
+      buffer: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: "0xffffffffffffffffffffffffffffffff",
+      buffer: [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff,
+      ],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Uint128.pack(makeJSBI(value))).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Uint128.unpack(Uint8Array.from(buffer))).toEqual(makeJSBI(value));
+    });
+
+    test("([0])", () => {
+      expect(() => Uint128.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 16, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Uint128.getSchema()).toEqual("array Uint128 [byte; 16];");
+  });
+});
+
+describe("Int128", () => {
+  describe(".safeParse", () => {
+    test.each([
+      "-0x80000000000000000000000000000000",
+      "0x7fffffffffffffffffffffffffffffff",
+    ])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Int128.safeParse(jsbi)).toEqual(mol.parseSuccess(jsbi));
+    });
+
+    test.each([
+      "-0x80000000000000000000000000000001",
+      "0x80000000000000000000000000000000",
+    ])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Int128.safeParse(jsbi)).toEqual(
+        mol.parseError(`Expected a valid number for Int128, got ${jsbi}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: "0",
+      buffer: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    {
+      value: "-0x80000000000000000000000000000000",
+      buffer: [
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x80,
+      ],
+    },
+    {
+      value: "-0x7fffffffffffffffffffffffffffffff",
+      buffer: [
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x80,
+      ],
+    },
+    {
+      value: "0x7fffffffffffffffffffffffffffffff",
+      buffer: [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0x7f,
+      ],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Int128.pack(makeJSBI(value))).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Int128.unpack(Uint8Array.from(buffer))).toEqual(makeJSBI(value));
+    });
+
+    test("([0])", () => {
+      expect(() => Int128.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 16, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Int128.getSchema()).toEqual("array Int128 [byte; 16];");
+  });
+});
+
+describe("Uint256", () => {
+  describe(".safeParse", () => {
+    test.each([
+      "0",
+      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    ])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Uint256.safeParse(jsbi)).toEqual(mol.parseSuccess(jsbi));
+    });
+
+    test.each([
+      "0x10000000000000000000000000000000000000000000000000000000000000000000",
+    ])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Uint256.safeParse(jsbi)).toEqual(
+        mol.parseError(`Expected a valid number for Uint256, got ${jsbi}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: "0",
+      buffer: [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+      ],
+    },
+    {
+      value: "1",
+      buffer: [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+      ],
+    },
+    {
+      value:
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      buffer: [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      ],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Uint256.pack(makeJSBI(value))).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Uint256.unpack(Uint8Array.from(buffer))).toEqual(makeJSBI(value));
+    });
+
+    test("([0])", () => {
+      expect(() => Uint256.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 32, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Uint256.getSchema()).toEqual("array Uint256 [byte; 32];");
+  });
+});
+
+describe("Int256", () => {
+  describe(".safeParse", () => {
+    test.each([
+      "-0x8000000000000000000000000000000000000000000000000000000000000000",
+      "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    ])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Int256.safeParse(jsbi)).toEqual(mol.parseSuccess(jsbi));
+    });
+
+    test.each([
+      "-0x8000000000000000000000000000000000000000000000000000000000000001",
+      "0x8000000000000000000000000000000000000000000000000000000000000000",
+    ])("(%s)", (input) => {
+      const jsbi = makeJSBI(input);
+      expect(Int256.safeParse(jsbi)).toEqual(
+        mol.parseError(`Expected a valid number for Int256, got ${jsbi}`),
+      );
+    });
+  });
+
+  const cases = [
+    {
+      value: "0",
+      buffer: [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+      ],
+    },
+    {
+      value:
+        "-0x8000000000000000000000000000000000000000000000000000000000000000",
+      buffer: [
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+      ],
+    },
+    {
+      value:
+        "-0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      buffer: [
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+      ],
+    },
+    {
+      value:
+        "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      buffer: [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f,
+      ],
+    },
+  ];
+
+  describe(".pack", () => {
+    test.each(cases)("($value)", ({ value, buffer }) => {
+      expect(Int256.pack(makeJSBI(value))).toEqual(Uint8Array.from(buffer));
+    });
+  });
+
+  describe(".unpack", () => {
+    test.each(cases)("($buffer)", ({ value, buffer }) => {
+      expect(Int256.unpack(Uint8Array.from(buffer))).toEqual(makeJSBI(value));
+    });
+
+    test("([0])", () => {
+      expect(() => Int256.unpack(Uint8Array.of(0))).toThrow(
+        "Expected bytes length 32, found 1",
+      );
+    });
+  });
+
+  test(".getSchema", () => {
+    expect(Int256.getSchema()).toEqual("array Int256 [byte; 32];");
+  });
+});
+
+const uintNCases: {
+  byteLength: number;
+  value: string;
+  expected: number[];
+  littleEndian: boolean;
+}[] = [
+  { byteLength: 1, value: "0", expected: [0], littleEndian: true },
+  { byteLength: 1, value: "1", expected: [1], littleEndian: true },
+  { byteLength: 1, value: "0", expected: [0], littleEndian: false },
+  { byteLength: 1, value: "1", expected: [1], littleEndian: false },
+
+  { byteLength: 2, value: "0", expected: [0, 0], littleEndian: true },
+  { byteLength: 2, value: "1", expected: [1, 0], littleEndian: true },
+  {
+    byteLength: 2,
+    value: "0xffff",
+    expected: [0xff, 0xff],
+    littleEndian: true,
+  },
+  { byteLength: 2, value: "0", expected: [0, 0], littleEndian: false },
+  { byteLength: 2, value: "1", expected: [0, 1], littleEndian: false },
+  {
+    byteLength: 2,
+    value: "0xffff",
+    expected: [0xff, 0xff],
+    littleEndian: false,
+  },
+
+  { byteLength: 3, value: "0", expected: [0, 0, 0], littleEndian: true },
+  { byteLength: 3, value: "1", expected: [1, 0, 0], littleEndian: true },
+  {
+    byteLength: 3,
+    value: "0xffffff",
+    expected: [0xff, 0xff, 0xff],
+    littleEndian: true,
+  },
+  { byteLength: 3, value: "0", expected: [0, 0, 0], littleEndian: false },
+  { byteLength: 3, value: "1", expected: [0, 0, 1], littleEndian: false },
+  {
+    byteLength: 3,
+    value: "0xffffff",
+    expected: [0xff, 0xff, 0xff],
+    littleEndian: false,
+  },
+
+  { byteLength: 4, value: "0", expected: [0, 0, 0, 0], littleEndian: true },
+  { byteLength: 4, value: "1", expected: [1, 0, 0, 0], littleEndian: true },
+  {
+    byteLength: 4,
+    value: "0xffffffff",
+    expected: [0xff, 0xff, 0xff, 0xff],
+    littleEndian: true,
+  },
+  { byteLength: 4, value: "0", expected: [0, 0, 0, 0], littleEndian: false },
+  { byteLength: 4, value: "1", expected: [0, 0, 0, 1], littleEndian: false },
+  {
+    byteLength: 4,
+    value: "0xffffffff",
+    expected: [0xff, 0xff, 0xff, 0xff],
+    littleEndian: false,
+  },
+
+  {
+    byteLength: 7,
+    value: "0",
+    expected: [0, 0, 0, 0, 0, 0, 0],
+    littleEndian: true,
+  },
+  {
+    byteLength: 7,
+    value: "1",
+    expected: [1, 0, 0, 0, 0, 0, 0],
+    littleEndian: true,
+  },
+  {
+    byteLength: 7,
+    value: "0xffffffffffffff",
+    expected: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+    littleEndian: true,
+  },
+  {
+    byteLength: 7,
+    value: "0",
+    expected: [0, 0, 0, 0, 0, 0, 0],
+    littleEndian: false,
+  },
+  {
+    byteLength: 7,
+    value: "1",
+    expected: [0, 0, 0, 0, 0, 0, 1],
+    littleEndian: false,
+  },
+  {
+    byteLength: 7,
+    value: "0xffffffffffffff",
+    expected: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+    littleEndian: false,
+  },
+
+  {
+    byteLength: 16,
+    value: "0",
+    expected: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    littleEndian: true,
+  },
+  {
+    byteLength: 16,
+    value: "1",
+    expected: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    littleEndian: true,
+  },
+  {
+    byteLength: 16,
+    value: "0xffffffffffffffffffffffffffffffff",
+    expected: [
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff,
+    ],
+    littleEndian: true,
+  },
+  {
+    byteLength: 16,
+    value: "0",
+    expected: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    littleEndian: false,
+  },
+  {
+    byteLength: 16,
+    value: "1",
+    expected: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+    littleEndian: false,
+  },
+  {
+    byteLength: 16,
+    value: "0xffffffffffffffffffffffffffffffff",
+    expected: [
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff,
+    ],
+    littleEndian: false,
+  },
+
+  {
+    byteLength: 17,
+    value: "0",
+    expected: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    littleEndian: true,
+  },
+  {
+    byteLength: 17,
+    value: "1",
+    expected: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    littleEndian: true,
+  },
+  {
+    byteLength: 17,
+    value: "0xffffffffffffffffffffffffffffffffff",
+    expected: [
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff, 0xff,
+    ],
+    littleEndian: true,
+  },
+  {
+    byteLength: 17,
+    value: "0",
+    expected: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    littleEndian: false,
+  },
+  {
+    byteLength: 17,
+    value: "1",
+    expected: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+    littleEndian: false,
+  },
+  {
+    byteLength: 17,
+    value: "0xffffffffffffffffffffffffffffffffff",
+    expected: [
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff, 0xff,
+    ],
+    littleEndian: false,
+  },
+];
+
+describe("packUintN", () => {
+  test.each(uintNCases)(
+    "($byteLength, $value, _, $littleEndian)",
+    ({ byteLength, value, expected, littleEndian }) => {
+      const jsbi = makeJSBI(value);
+      const buffer = new Uint8Array(byteLength);
+      packUintN(byteLength, jsbi, buffer, littleEndian);
+      expect(buffer).toEqual(Uint8Array.from(expected));
+    },
+  );
+});
+
+describe("unpackUintN", () => {
+  test.each(uintNCases)(
+    "($byteLength, $expected, $littleEndian)",
+    ({ byteLength, value, expected, littleEndian }) => {
+      const jsbi = makeJSBI(value);
+      const actual = unpackUintN(
+        byteLength,
+        Uint8Array.from(expected),
+        littleEndian,
+      );
+      expect(actual).toEqual(jsbi);
+    },
+  );
+});

--- a/packages/molecule-jsbi/src/index.ts
+++ b/packages/molecule-jsbi/src/index.ts
@@ -1,0 +1,217 @@
+/**
+ * Number Codecs of integers using JSBI.
+ * @module
+ * @example
+ * ```ts
+ * import { Uint64 } from "@ckb-lumos/molecule-jsbi";
+ * import JSBI from "jsbi";
+ * const buffer = Uint64.pack(JSBI.BigInt(1));
+ * console.log(buffer);
+ * // => [1, 0, 0, 0, 0, 0, 0, 0],
+ * console.log(JSBI.toNumber(Uint64.unpack(buffer)));
+ * // => 1
+ * ```
+ */
+import JSBI from "jsbi";
+import { NumberCodec, NumberCodecSpec } from "@ckb-cobuild/molecule";
+
+/**
+ * A wrapper of JSBI.BigInt to support negative hex string.
+ */
+export function makeJSBI(arg: number | string | boolean | object): JSBI {
+  if (typeof arg === "string" && arg.startsWith("-")) {
+    return JSBI.unaryMinus(JSBI.BigInt(arg.slice(1)));
+  }
+  return JSBI.BigInt(arg);
+}
+
+const ZERO = JSBI.BigInt(0);
+const MIN_BIG_UINT64 = ZERO;
+const MAX_BIG_UINT64 = JSBI.BigInt("0xffffffffffffffff");
+
+export function createBigUint64Codec(
+  name: string,
+  littleEndian: boolean,
+): NumberCodec<JSBI> {
+  return new NumberCodec(name, 8, {
+    checkNumber(value) {
+      return (
+        value instanceof JSBI &&
+        JSBI.greaterThanOrEqual(value, MIN_BIG_UINT64) &&
+        JSBI.lessThanOrEqual(value, MAX_BIG_UINT64)
+      );
+    },
+    packNumberTo(value, buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      JSBI.DataViewSetBigUint64(view, 0, value, littleEndian);
+    },
+    unpackNumber(buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      return JSBI.DataViewGetBigUint64(view, 0, littleEndian);
+    },
+  });
+}
+export const Uint64 = createBigUint64Codec("Uint64", true);
+
+const MIN_BIG_INT64 = JSBI.unaryMinus(JSBI.BigInt("0x8000000000000000"));
+const MAX_BIG_INT64 = JSBI.BigInt("0x7fffffffffffffff");
+
+export function createBigInt64Codec(
+  name: string,
+  littleEndian: boolean,
+): NumberCodec<JSBI> {
+  return new NumberCodec(name, 8, {
+    checkNumber(value) {
+      return (
+        value instanceof JSBI &&
+        JSBI.greaterThanOrEqual(value, MIN_BIG_INT64) &&
+        JSBI.lessThanOrEqual(value, MAX_BIG_INT64)
+      );
+    },
+    packNumberTo(value, buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      JSBI.DataViewSetBigInt64(view, 0, value, littleEndian);
+    },
+    unpackNumber(buffer) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      return JSBI.DataViewGetBigInt64(view, 0, littleEndian);
+    },
+  });
+}
+export const Int64 = createBigInt64Codec("Int64", true);
+
+const UINT32_MASK = JSBI.BigInt(0xffffffff);
+const UINT32_SHIFT = JSBI.BigInt(32);
+const UINT8_MASK = JSBI.BigInt(0xff);
+const UINT8_SHIFT = JSBI.BigInt(8);
+
+export function packUintN(
+  byteLength: number,
+  value: JSBI,
+  buffer: Uint8Array,
+  littleEndian: boolean,
+) {
+  const view = new DataView(buffer.buffer, buffer.byteOffset);
+
+  let remainingBytes = byteLength;
+  let remainingValue = JSBI.asUintN(byteLength << 3, value);
+  let [offset, step] = littleEndian ? [0, 4] : [byteLength - 4, -4];
+
+  while (remainingBytes >= 4) {
+    view.setUint32(
+      offset,
+      JSBI.toNumber(JSBI.bitwiseAnd(remainingValue, UINT32_MASK)),
+      littleEndian,
+    );
+
+    offset += step;
+    remainingBytes -= 4;
+    remainingValue = JSBI.signedRightShift(remainingValue, UINT32_SHIFT);
+  }
+
+  step = littleEndian ? 1 : -1;
+  if (!littleEndian) {
+    offset += 3;
+  }
+
+  while (remainingBytes > 0) {
+    view.setUint8(
+      offset,
+      JSBI.toNumber(JSBI.bitwiseAnd(remainingValue, UINT8_MASK)),
+    );
+
+    offset += step;
+    remainingBytes -= 1;
+    remainingValue = JSBI.signedRightShift(remainingValue, UINT8_SHIFT);
+  }
+}
+
+export function unpackUintN(
+  byteLength: number,
+  buffer: Uint8Array,
+  littleEndian: boolean,
+): JSBI {
+  const view = new DataView(buffer.buffer, buffer.byteOffset);
+
+  let remainingBytes = byteLength;
+  let value = ZERO;
+  let [offset, step] = littleEndian ? [byteLength - 4, -4] : [0, 4];
+
+  while (remainingBytes >= 4) {
+    if (JSBI.notEqual(value, ZERO)) {
+      value = JSBI.leftShift(value, UINT32_SHIFT);
+    }
+    value = JSBI.add(value, JSBI.BigInt(view.getUint32(offset, littleEndian)));
+
+    offset += step;
+    remainingBytes -= 4;
+  }
+
+  step = littleEndian ? -1 : 1;
+  if (littleEndian) {
+    offset += 3;
+  }
+
+  while (remainingBytes > 0) {
+    value = JSBI.leftShift(value, UINT8_SHIFT);
+    value = JSBI.add(value, JSBI.BigInt(view.getUint8(offset)));
+
+    offset += step;
+    remainingBytes -= 1;
+  }
+
+  return value;
+}
+
+export function createBigUintNCodecSpec(
+  fixedByteLength: number,
+  littleEndian: boolean,
+): NumberCodecSpec<JSBI> {
+  return {
+    checkNumber(value) {
+      return JSBI.asUintN(fixedByteLength << 3, value) === value;
+    },
+    packNumberTo(value, buffer) {
+      return packUintN(fixedByteLength, value, buffer, littleEndian);
+    },
+    unpackNumber(buffer) {
+      return unpackUintN(fixedByteLength, buffer, littleEndian);
+    },
+  };
+}
+
+export function createBigUintNCodec(
+  name: string,
+  fixedByteLength: number,
+  littleEndian: boolean,
+): NumberCodec<JSBI> {
+  return new NumberCodec<JSBI>(
+    name,
+    fixedByteLength,
+    createBigUintNCodecSpec(fixedByteLength, littleEndian),
+  );
+}
+export const Uint128 = createBigUintNCodec("Uint128", 16, true);
+export const Uint256 = createBigUintNCodec("Uint256", 32, true);
+
+export function createBigIntNCodec(
+  name: string,
+  fixedByteLength: number,
+  littleEndian: boolean,
+): NumberCodec<JSBI> {
+  const spec = createBigUintNCodecSpec(fixedByteLength, littleEndian);
+  const bitLength = fixedByteLength << 3;
+  return new NumberCodec<JSBI>(name, fixedByteLength, {
+    checkNumber(value) {
+      return JSBI.asIntN(bitLength, value) === value;
+    },
+    packNumberTo(value, buffer) {
+      return spec.packNumberTo(JSBI.asUintN(bitLength, value), buffer);
+    },
+    unpackNumber(buffer) {
+      return JSBI.asIntN(bitLength, spec.unpackNumber(buffer));
+    },
+  });
+}
+export const Int128 = createBigIntNCodec("Int128", 16, true);
+export const Int256 = createBigIntNCodec("Int256", 32, true);

--- a/packages/molecule-jsbi/tsconfig.json
+++ b/packages/molecule-jsbi/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/molecule-jsbi/typedoc.json
+++ b/packages/molecule-jsbi/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "includeVersion": true
+}

--- a/packages/molecule/README.md
+++ b/packages/molecule/README.md
@@ -7,7 +7,8 @@ An opinionated [molecule](https://github.com/nervosnetwork/molecule) library whi
 
 ## More Codecs
 
-- `@ckb-cobuild/molecule-bigint`: 64-bit integer codecs for native bigint.
+- `@ckb-cobuild/molecule-bigint`: BigInt codecs for native bigint.
+- `@ckb-cobuild/molecule-jsbi`: BigInt integer codecs via JSBI.
 
 ## Browser Compatibility
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,37 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1(typescript@5.2.2)
 
+  packages/molecule-jsbi:
+    dependencies:
+      '@ckb-cobuild/molecule':
+        specifier: workspace:^
+        version: link:../molecule
+      jsbi:
+        specifier: ^4.3.0
+        version: 4.3.0
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/tsup-patcher':
+        specifier: workspace:*
+        version: link:../tsup-patcher
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/jest':
+        specifier: ^29.5.11
+        version: 29.5.11
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.11.20)
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.1.1(@babel/core@7.23.3)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.2.2)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.0.1(typescript@5.2.2)
+
   packages/tsup-patcher: {}
 
   packages/typescript-config: {}


### PR DESCRIPTION
```ts
 import { Uint64 } from "@ckb-lumos/molecule-jsbi";
 import JSBI from "jsbi";
 const buffer = Uint64.pack(JSBI.BigInt(1));
 console.log(buffer);
 // => [1, 0, 0, 0, 0, 0, 0, 0],
 console.log(JSBI.toNumber(Uint64.unpack(buffer)));
 // => 1
```